### PR TITLE
Doc randomize

### DIFF
--- a/pttrack/models.py
+++ b/pttrack/models.py
@@ -4,6 +4,7 @@ from django.core.exceptions import ValidationError
 from django.contrib.auth.models import User
 from django.conf import settings
 import django.utils.timezone
+import os
 
 from simple_history.models import HistoricalRecords
 

--- a/pttrack/models.py
+++ b/pttrack/models.py
@@ -51,6 +51,34 @@ def validate_attending(value):
     return value.can_attend
 
 
+def make_filepath(instance, filename):
+    '''
+        Produces a unique file path for the upload_to of a FileField. This is
+        important because any URL is 1) transmitted unencrypted and 2) 
+        automatically referred to any libraries we include (i.e. Bootstrap,
+        AngularJS).
+
+        The produced path is of the form:
+        "[model name]/[field name]/[random name].[filename extension]".
+
+        Copypasta from https://djangosnippets.org/snippets/2819/
+    '''
+
+
+    field_name = 'image'
+    carry_on = True
+    while carry_on:
+        new_filename = "%s.%s" % (User.objects.make_random_password(48),
+                                  filename.split('.')[-1])
+        path = '/'.join([instance.__class__.__name__.lower(),
+                         field_name, new_filename])
+
+        # if the file already exists, try again to generate a new filename
+        carry_on = os.path.isfile(os.path.join(settings.MEDIA_ROOT, path))
+
+    return path
+
+
 class ContactMethod(models.Model):
     '''Simple text-contiaining class for storing the method of contacting a
     patient for followup followed up with (i.e. phone, email, etc.)'''
@@ -342,7 +370,13 @@ class DocumentType(models.Model):
 
 class Document(Note):
     title = models.CharField(max_length=200)
+<<<<<<< HEAD
     image = models.ImageField()
+=======
+    image = models.ImageField(
+        help_text="Please deidentify all file names before upload!",
+        upload_to=make_filepath)
+>>>>>>> got rid of the use of functools and partial since it was causing errors
     comments = models.TextField()
     document_type = models.ForeignKey(DocumentType)
 

--- a/pttrack/tests.py
+++ b/pttrack/tests.py
@@ -225,9 +225,16 @@ class ViewsExistTest(TestCase):
             author_type=models.ProviderType.objects.all()[0])
 
         p = models.Document.objects.get(id=1).image.path
+        random_name = p.split("/")[-1]
+        random_name = random_name.split(".")[0]
         self.failUnless(open(p), 'file not found')
         self.assertEqual(doc.image.path, p)
         self.assertTrue(os.path.isfile(p))
+
+        # Checking to make sure the path is 48 characters (the length of the random password
+
+        self.assertEqual(len(random_name), 48)
+
 
         url = reverse('document-detail', args=(1,))
         response = self.client.get(url)
@@ -245,9 +252,15 @@ class ViewsExistTest(TestCase):
                 author_type=models.ProviderType.objects.all()[0])
 
             p = models.Document.objects.get(id=doc.pk).image.path
+            random_name = p.split("/")[-1]
+            random_name = random_name.split(".")[0]
             self.failUnless(open(p), 'file not found')
             self.assertEqual(doc.image.path, p)
             self.assertTrue(os.path.isfile(p))
+
+            # Checking to make sure the path is 48 characters (the length of the random password
+
+            self.assertEqual(len(random_name), 48)
 
             url = reverse('document-detail', args=(doc.pk,))
             response = self.client.get(url)


### PR DESCRIPTION
The error was mainly with the fact that we were using partial. The copypasta used was in Django 1.4 that would allow that, but Djano 1.7 will not. Since you were not changing the field_name 'image' to anything different, I just hard coded it into the function. We can just create separate functions if we want different folders for different images later.