### PR TITLE
Multiple small changes to Patient and Provider creation.

### DIFF
--- a/clintools/deploy_settings.py
+++ b/clintools/deploy_settings.py
@@ -9,6 +9,9 @@ with open(os.path.join(BASE_DIR, 'secrets/secret_key.txt')) as f:
 SECURE_CONTENT_TYPE_NOSNIFF = True
 SECURE_BROWSER_XSS_FILTER = True
 
+# one day in seconds
+SESSION_COOKIE_AGE = 86400
+
 # it would be nice to enable this, but we go w/o SSL from the WashU load
 # balancer, meaning infinite redirects if we enable this :(
 # SECURE_SSL_REDIRECT = True

--- a/pttrack/views.py
+++ b/pttrack/views.py
@@ -114,8 +114,14 @@ class ProviderCreate(FormView):
     def form_valid(self, form):
         provider = form.save(commit=False)
         provider.associated_user = self.request.user
+
+        # populate the User object with the email and name data from the
+        # Provider form
         user = provider.associated_user
         user.email = form.cleaned_data['provider_email']
+        user.first_name = provider.first_name
+        user.last_name = provider.last_name
+        
         user.save()
         provider.save()
         form.save_m2m()
@@ -218,7 +224,8 @@ class WorkupUpdate(NoteUpdate):
                 wu.save()
                 return HttpResponseRedirect(reverse("workup", args=(wu.id,)))
             else:
-                return HttpResponseRedirect(reverse("workup-error", args=(wu.id,)))
+                return HttpResponseRedirect(reverse("workup-error",
+                                                    args=(wu.id,)))
 
 
 
@@ -340,6 +347,9 @@ class PatientCreate(FormView):
 
         # Action of creating the patient should indicate the patient is active (needs a workup)
         pt.needs_workup = True
+
+        if not '-' in pt.ssn:
+            pt.ssn = pt.ssn[0:3] + '-' + pt.ssn[3:5] + '-' + pt.ssn[5:]
 
         pt.save()
         return HttpResponseRedirect(reverse("patient-detail",


### PR DESCRIPTION
Refactor a few tests, add additional tests for alt phones, add a test for SSNs. Add SSN and SSN validation to Patient. Remove a stray '}}' from the workup-detail view.

Provider last_name and first_name should now write through to the User model. Test also written to verify this. Test for Provider registration modified as well to share work with new test.

Add help text to Langauges

Tests.py now uses one BASIC_FIXTURES static global variable to find the basic database setup.

Addresses #41. All tests pass.