### PR TITLE
Require role selection before submit

### DIFF
--- a/pttrack/templates/pttrack/role-choice.html
+++ b/pttrack/templates/pttrack/role-choice.html
@@ -21,7 +21,7 @@ Choose Clinical Role
     <div class="row">
     {% for role in roles %}
     <label class="radio-inline">
-      <input type="radio" name="{{choice_key}}" value="{{role}}">
+      <input type="radio" name="{{choice_key}}" value="{{role}}" required>
       {{ role }}
     </label>
     {% endfor %}


### PR DESCRIPTION
#122 @justinrporter 
Enforcing role selection client-side. I'm thinking this could be sufficient? It's probably someone who carelessly clicked submit, rather than that people are maliciously trying to break it.

The only thing is that the aesthetic looks different, it's the html notice
![image](https://cloud.githubusercontent.com/assets/16888998/17465320/e03de4a4-5cb9-11e6-9e61-fa353872da04.png)
rather than the Django form notice
![image](https://cloud.githubusercontent.com/assets/16888998/17465323/ed4cdd94-5cb9-11e6-8a91-6a9a73b279ca.png)
