### PR TITLE
Fixed the Chrome error message issue

### DIFF
--- a/workup/models.py
+++ b/workup/models.py
@@ -7,7 +7,7 @@ from django.core.urlresolvers import reverse
 from pttrack.models import Note, Provider, ReferralLocation, ReferralType
 from pttrack.validators import validate_attending
 
-from .validators import validate_bp
+from .validators import validate_bp, validate_hr, validate_rr, validate_t, validate_height, validate_weight
 
 
 class DiagnosisType(models.Model):
@@ -58,17 +58,16 @@ class Workup(Note):
     soc_hx = models.TextField(verbose_name="Social History")
     ros = models.TextField(verbose_name="ROS")
 
-    hr = models.PositiveSmallIntegerField(blank=True, null=True)
-    bp = models.CharField(blank=True, null=True,
-                          max_length=7,
-                          validators=[validate_bp])
+    hr = models.CharField(blank=True, null=True, max_length=12, validators=[validate_hr])
+    bp = models.CharField(blank=True, null=True, max_length=12, validators=[validate_bp])
 
-    rr = models.PositiveSmallIntegerField(blank=True, null=True)
-    t = models.DecimalField(max_digits=3,
-                            decimal_places=1,
-                            blank=True, null=True)
-    height = models.PositiveSmallIntegerField(blank=True, null=True)
-    weight = models.PositiveSmallIntegerField(blank=True, null=True)
+    rr = models.CharField(blank=True, null=True, max_length=12, validators=[validate_rr])
+    t = models.CharField(blank=True, null=True, max_length=12, validators=[validate_t])
+
+    # this is a hotfix that needs to be changed in terms of error handeling for the entire form so that 
+    # people are not confused when they cannot submit their form.
+    height = models.CharField(blank=True, null=True, max_length=12, validators=[validate_height])
+    weight = models.CharField(blank=True, null=True, max_length=12, validators=[validate_weight])
 
     pe = models.TextField(verbose_name="Physical Examination")
 

--- a/workup/tests.py
+++ b/workup/tests.py
@@ -60,6 +60,73 @@ class TestModelFieldValidators(TestCase):
         with self.assertRaises(ValidationError):
             validators.validate_bp("200/20")
 
+    def test_validate_hr(self):
+        '''
+        Test our validator for heart rate.
+        '''
+        self.assertEqual(validators.validate_hr("100"), None)
+        self.assertEqual(validators.validate_hr("90"), None)
+
+        with self.assertRaises(ValidationError):
+            validators.validate_hr("902/")
+        with self.assertRaises(ValidationError):
+            validators.validate_hr("..90")
+        with self.assertRaises(ValidationError):
+            validators.validate_hr("93.232")
+
+    def test_validate_rr(self):
+        '''
+        Test our validator for heart rate.
+        '''
+        self.assertEqual(validators.validate_rr("100"), None)
+        self.assertEqual(validators.validate_rr("90"), None)
+
+        with self.assertRaises(ValidationError):
+            validators.validate_rr("90/")
+        with self.assertRaises(ValidationError):
+            validators.validate_rr("..90")
+        with self.assertRaises(ValidationError):
+            validators.validate_rr("93.232")
+
+    def test_validate_t(self):
+        '''
+        Test our validator for heart rate.
+        '''
+        self.assertEqual(validators.validate_t("100.11"), None)
+        self.assertEqual(validators.validate_t("90.21"), None)
+
+        with self.assertRaises(ValidationError):
+            validators.validate_t("90x")
+
+
+    def test_validate_height(self):
+        '''
+        Test our validator for heart rate.
+        '''
+        self.assertEqual(validators.validate_height("100"), None)
+        self.assertEqual(validators.validate_height("90"), None)
+
+        with self.assertRaises(ValidationError):
+            validators.validate_height("90x")
+        with self.assertRaises(ValidationError):
+            validators.validate_height("90.0")
+        with self.assertRaises(ValidationError):
+            validators.validate_height("93.232")
+
+    def test_validate_weight(self):
+        '''
+        Test our validator for heart rate.
+        '''
+        self.assertEqual(validators.validate_weight("100"), None)
+        self.assertEqual(validators.validate_weight("90"), None)
+
+        with self.assertRaises(ValidationError):
+            validators.validate_weight("90x")
+        with self.assertRaises(ValidationError):
+            validators.validate_weight("9.0")
+        with self.assertRaises(ValidationError):
+            validators.validate_weight("93.232")
+
 
 class TestWorkupModel(TestCase):
 

--- a/workup/validators.py
+++ b/workup/validators.py
@@ -65,10 +65,10 @@ def validate_rr(value):
 def validate_t(value):
     '''validate that a value is a valid temperature'''
     try:
-        temperature = int(value)
+        temperature = float(value)
     except ValueError:
         raise ValidationError(
-            str(value) + " is not a integer")
+            str(value) + " is not a decimal value")
 
     if temperature < 1:
         raise ValidationError(

--- a/workup/validators.py
+++ b/workup/validators.py
@@ -36,3 +36,64 @@ def validate_bp(value):
     if diastolic < MIN_DIASOLIC:
         raise ValidationError(
             "Diastolic bp (%s) is unreasonably low." % diastolic)
+
+
+def validate_hr(value):
+    '''validate that a value is a valid heart rate'''
+    try:
+        heart_rate = int(value)
+    except ValueError:
+        raise ValidationError(
+            str(value) + " is not a integer")
+
+    if heart_rate < 1:
+        raise ValidationError(
+            str(value) + " is not a positive number")
+
+def validate_rr(value):
+    '''validate that a value is a valid respiratory rate'''
+    try:
+        r_rate = int(value)
+    except ValueError:
+        raise ValidationError(
+            str(value) + " is not a integer")
+
+    if r_rate < 1:
+        raise ValidationError(
+            str(value) + " is not a positive number")
+
+def validate_t(value):
+    '''validate that a value is a valid temperature'''
+    try:
+        temperature = int(value)
+    except ValueError:
+        raise ValidationError(
+            str(value) + " is not a integer")
+
+    if temperature < 1:
+        raise ValidationError(
+            str(value) + " is not a positive number")
+
+def validate_height(value):
+    '''validate that a value is a valid temperature'''
+    try:
+        height = int(value)
+    except ValueError:
+        raise ValidationError(
+            str(value) + " is not a integer")
+
+    if height < 1:
+        raise ValidationError(
+            str(value) + " is not a positive number")
+
+def validate_weight(value):
+    '''validate that a value is a valid temperature'''
+    try:
+        weight = int(value)
+    except ValueError:
+        raise ValidationError(
+            str(value) + " is not a integer")
+
+    if weight< 1:
+        raise ValidationError(
+            str(value) + " is not a positive number")


### PR DESCRIPTION
The issue stems on how Chrome handles html error validation. Chrome has to see the box that it will push an error notification on, and crispy forms will hide the boxes within tabs and so the submit button will not perform anything. However, if the validation is done by separate validators in javascript, then it will work and redirect to the correct tab. This problem is not seen on Safari and Firefox. I think we will eventually migrate workup to form-wizard anyway and stop relying on tabs.

Reference:  http://stackoverflow.com/questions/22148080/an-invalid-form-control-with-name-is-not-focusable