### PR TITLE
Workup ClinicDay specification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ jobs:
           command: |
             . venv/bin/activate
             coverage run --source='.' ./manage.py test
+            codecov -t 3255dabc-78eb-459a-a4c7-c43efcbb1718
       - store_artifacts:
           path: test-reports/
           destination: tr1

--- a/osler.sublime-project
+++ b/osler.sublime-project
@@ -21,6 +21,9 @@
 	"folders":
 	[
 		{
+			"path": ".circleci"
+		},
+		{
 			"file_exclude_patterns":
 			[
 				"__init__.py"

--- a/osler/base_settings.py
+++ b/osler/base_settings.py
@@ -101,3 +101,9 @@ OSLER_MIN_DIASTOLIC = 40
 
 OSLER_MAX_APPOINTMENTS = 5
 OSLER_DEFAULT_APPOINTMENT_HOUR = 9
+
+OSLER_WORKUP_COPY_FORWARD_FIELDS = ['PMH_PSH', 'fam_hx', 'soc_hx', 'meds',
+                                    'allergies']
+OSLER_WORKUP_COPY_FORWARD_MESSAGE = ("Migrated from previous workup on {date}"
+                                     ". Please delete this heading and modify "
+                                     "the following:\n\n{contents}")

--- a/workup/forms.py
+++ b/workup/forms.py
@@ -3,13 +3,13 @@ from decimal import Decimal, ROUND_HALF_UP
 from django.forms import (
     fields, ModelForm, CheckboxSelectMultiple, ModelChoiceField,
     ModelMultipleChoiceField, RadioSelect
-    )
+)
 
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Submit, Layout, Div, Field, Row, HTML
 from crispy_forms.bootstrap import (
     InlineCheckboxes, AppendedText, PrependedText
-    )
+)
 
 from pttrack.models import Provider, ProviderType
 from . import models
@@ -54,7 +54,7 @@ def fahrenheit2centigrade(f):
     centigrade. If None, returns None.
     """
     if f is not None:
-        return (f - 32) / Decimal(9.0/5.0)
+        return (f - 32) / Decimal(9.0 / 5.0)
     else:
         return None
 
@@ -108,7 +108,7 @@ class WorkupForm(ModelForm):
 
     class Meta:
         model = models.Workup
-        exclude = ['patient', 'clinic_day', 'author', 'signer', 'author_type',
+        exclude = ['patient', 'author', 'signer', 'author_type',
                    'signed_date']
         widgets = {'referral_location': CheckboxSelectMultiple,
                    'referral_type': CheckboxSelectMultiple}
@@ -121,14 +121,14 @@ class WorkupForm(ModelForm):
         queryset=Provider.objects.filter(
             clinical_roles__in=ProviderType.objects.filter(
                 signs_charts=True)).order_by("last_name")
-        )
+    )
 
     other_volunteer = ModelMultipleChoiceField(
         required=False,
         queryset=Provider.objects.filter(
             clinical_roles__in=ProviderType.objects.filter(
                 signs_charts=False)).distinct().order_by("last_name"),
-        )
+    )
 
     def __init__(self, *args, **kwargs):
         super(WorkupForm, self).__init__(*args, **kwargs)
@@ -139,7 +139,9 @@ class WorkupForm(ModelForm):
         self.helper.layout = Layout(
             Row(HTML('<h3>Clinical Team</h3>'),
                 Div('attending', css_class='col-sm-6'),
-                Div('other_volunteer',  css_class='col-sm-6')),
+                Div('other_volunteer', css_class='col-sm-6'),
+                Div('clinic_day', css_class='col-sm-12')
+                ),
 
             Row(HTML('<h3>History</h3>'),
                 Div('chief_complaint', css_class='col-sm-6'),
@@ -268,7 +270,6 @@ class ClinicDateForm(ModelForm):
     class Meta:
         model = models.ClinicDate
         exclude = ['clinic_date', 'gcal_id']
-
 
     def __init__(self, *args, **kwargs):
         super(ClinicDateForm, self).__init__(*args, **kwargs)

--- a/workup/models.py
+++ b/workup/models.py
@@ -41,6 +41,7 @@ class ClinicDate(models.Model):
     def __unicode__(self):
         return str(self.clinic_type)+" ("+str(self.clinic_date)+")"
 
+
 class ProgressNote(Note):
     title = models.CharField(max_length=200)
     text = models.TextField()
@@ -49,6 +50,7 @@ class ProgressNote(Note):
 
     def short_text(self):
         return self.title
+
 
 class Workup(Note):
     '''Datamodel of a workup. Has fields specific to each part of an exam,
@@ -63,7 +65,7 @@ class Workup(Note):
         Provider, blank=True, related_name="other_volunteer",
         help_text="Which other volunteer(s) did you work with (if any)?")
 
-    clinic_day = models.ForeignKey(ClinicDate)
+    clinic_day = models.ForeignKey(ClinicDate, help_text="When was the patient seen?")
 
     chief_complaint = models.CharField(max_length=1000, verbose_name="CC")
     diagnosis = models.CharField(max_length=1000, verbose_name="Dx")

--- a/workup/test_forms.py
+++ b/workup/test_forms.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 
 from pttrack.models import Provider, ProviderType, Gender
 
-from .models import DiagnosisType
+from .models import DiagnosisType, ClinicDate, ClinicType
 from .forms import WorkupForm
 
 from .tests import wu_dict
@@ -27,9 +27,13 @@ class TestWorkupFormUnitAwareFields(TestCase):
 
     def setUp(self):
         DiagnosisType.objects.create(name='Cardiovascular')
+        ClinicType.objects.create(name='Main Clinic')
+        ClinicDate.objects.create(
+            clinic_date='2018-08-26', clinic_type=ClinicType.objects.first())
 
         wu_data = wu_dict()
         wu_data['diagnosis_categories'] = [DiagnosisType.objects.first().pk]
+        wu_data['clinic_day'] = wu_data['clinic_day'].pk
         wu_data['got_imaging_voucher'] = False
         wu_data['got_voucher'] = False
 
@@ -58,9 +62,7 @@ class TestWorkupFormUnitAwareFields(TestCase):
     def test_vitals_no_value_no_units_ok(self):
         """Units are required only when vitals are provided."""
 
-        wu_data = self.wu_data
-
-        form = WorkupForm(data=wu_data)
+        form = WorkupForm(data=self.wu_data)
         self.assertTrue(form.is_valid(), msg=form.errors)
 
     def test_note_temp_conversion(self):

--- a/workup/tests.py
+++ b/workup/tests.py
@@ -14,21 +14,20 @@ from . import models
 
 
 def wu_dict(units=False):
-    wu = {
-            'clinic_day': models.ClinicDate.objects.first(),
-            'chief_complaint': "SOB",
-            'diagnosis': "MI",
-            'HPI': "f", 'PMH_PSH': "f", 'meds': "f", 'allergies': "f",
-            'fam_hx': "f", 'soc_hx': "f",
-            'ros': "f", 'pe': "f", 'A_and_P': "f",
-            'hr': '89', 'bp_sys': '120', 'bp_dia': '80', 'rr': '16', 't': '98',
-            'labs_ordered_internal': 'f', 'labs_ordered_quest': 'f',
-            'got_voucher': False,
-            'got_imaging_voucher': False,
-            'will_return': True,
-            'author': Provider.objects.first(),
-            'author_type': ProviderType.objects.first(),
-            'patient': Patient.objects.first()
+    wu = {'clinic_day': models.ClinicDate.objects.first(),
+          'chief_complaint': "SOB",
+          'diagnosis': "MI",
+          'HPI': "f", 'PMH_PSH': "f", 'meds': "f", 'allergies': "f",
+          'fam_hx': "f", 'soc_hx': "f",
+          'ros': "f", 'pe': "f", 'A_and_P': "f",
+          'hr': '89', 'bp_sys': '120', 'bp_dia': '80', 'rr': '16', 't': '98',
+          'labs_ordered_internal': 'f', 'labs_ordered_quest': 'f',
+          'got_voucher': False,
+          'got_imaging_voucher': False,
+          'will_return': True,
+          'author': Provider.objects.first(),
+          'author_type': ProviderType.objects.first(),
+          'patient': Patient.objects.first()
         }
 
     if units:

--- a/workup/views.py
+++ b/workup/views.py
@@ -1,12 +1,12 @@
 from django.shortcuts import get_object_or_404, render
-from django.http import HttpResponseRedirect, HttpResponseServerError, \
-    HttpResponse
+from django.http import (HttpResponseRedirect, HttpResponseServerError,
+                         HttpResponse)
 from django.core.urlresolvers import reverse
-from django.template import Context
 from django.template.loader import get_template
 from django.utils.timezone import now
 from django.views.generic.edit import FormView
 from django.views.generic.list import ListView
+from django.conf import settings
 
 from pttrack.views import NoteFormView, NoteUpdate, get_current_provider_type
 from pttrack.models import Patient, ProviderType
@@ -60,17 +60,19 @@ class WorkupCreate(NoteFormView):
     def get_initial(self):
         initial = super(WorkupCreate, self).get_initial()
         pt = get_object_or_404(Patient, pk=self.kwargs['pt_id'])
+
+        # self.get() checks for >= 1 ClinicDay
+        initial['clinic_day'] = get_clindates().first()
+        initial['ros'] = "Default: reviewed and negative"
+
         wu_previous = pt.latest_workup()
         if wu_previous is not None:
             date_string = wu_previous.written_datetime.strftime("%B %d, %Y")
-            heading_text = "Migrated from previous workup on " + date_string + ". Please delete this heading and modify the following:\n\n"
-            initial['PMH_PSH'] = heading_text + wu_previous.PMH_PSH
-            initial['fam_hx'] = heading_text + wu_previous.fam_hx
-            initial['soc_hx'] = heading_text + wu_previous.soc_hx
-            initial['meds'] = heading_text + wu_previous.meds
-            initial['allergies'] = heading_text + wu_previous.allergies
+            for field in settings.OSLER_WORKUP_COPY_FORWARD_FIELDS:
+                initial[field] = settings.OSLER_WORKUP_COPY_FORWARD_MESSAGE.\
+                    format(date=date_string,
+                           contents=getattr(wu_previous, field))
 
-        initial['ros'] = "Default: reviewed and negative"
         return initial
 
     def form_valid(self, form):
@@ -83,7 +85,6 @@ class WorkupCreate(NoteFormView):
         wu.patient = pt
         wu.author = self.request.user.provider
         wu.author_type = get_current_provider_type(self.request)
-        wu.clinic_day = get_clindates()[0]
         if wu.author_type.signs_charts:
             wu.sign(self.request.user, active_provider_type)
 


### PR DESCRIPTION
Fixes an issue where if the day would roll over while a user had a new workup open, no clinic day would be available to associate with the Workup.

- Makes ClinicDay modifiable
- Fixes workup day rollover bug