### PR TITLE
Compatibility of serializers with DRF v3

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -24,6 +24,7 @@ class HistorySerializer(serializers.Serializer):
 class ClinicDateSerializer(serializers.ModelSerializer):
     class Meta:
         model = workupModels.ClinicDate
+        exclude = []
 
 
 class WorkupSerializer(serializers.ModelSerializer):
@@ -47,6 +48,7 @@ class CaseManagerSerializer(serializers.ModelSerializer):
 class PatientSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Patient
+        exclude = []
 
     history = HistorySerializer()
     latest_workup = WorkupSerializer()

--- a/api/views.py
+++ b/api/views.py
@@ -16,6 +16,8 @@ def active_patients_filter(qs):
     giving care on a particular clinic day (to hide the giant list of
     pts).
     '''
+
+    print('hi')
     return qs.filter(needs_workup__exact=True).order_by('last_name')
 
 


### PR DESCRIPTION
Add `exclude=[]` in `ModelSerializers` for compatibility with DRF v3.